### PR TITLE
Fix pv package typo

### DIFF
--- a/home/.data/packages.yaml
+++ b/home/.data/packages.yaml
@@ -170,7 +170,7 @@
 - scoop: psfzf
 
 - brew: pv
-  dev: pv
+  deb: pv
   dnf: pv
 
 - brew: python@3.13


### PR DESCRIPTION
Hi,

I've been using your dotfiles as an introduction to chezmoi and I found this error you may want to fix: you've specified a package manager label "dev" when you probably meant "deb".
